### PR TITLE
Hard Cap on Price Impact in Virtual Buyback

### DIFF
--- a/src/LiquidationPairFactory.sol
+++ b/src/LiquidationPairFactory.sol
@@ -33,7 +33,8 @@ contract LiquidationPairFactory {
     UFixed32x4 liquidityFraction,
     uint128 virtualReserveIn,
     uint128 virtualReserveOut,
-    uint256 minK
+    uint256 minK,
+    UFixed32x4 maxPriceImpact
   );
 
   /* ============ Variables ============ */
@@ -68,7 +69,8 @@ contract LiquidationPairFactory {
     UFixed32x4 _liquidityFraction,
     uint128 _virtualReserveIn,
     uint128 _virtualReserveOut,
-    uint256 _mink
+    uint256 _mink,
+    UFixed32x4 _maxPriceImpact
   ) external returns (LiquidationPair) {
     LiquidationPair _liquidationPair = new LiquidationPair(
       _source,
@@ -78,7 +80,8 @@ contract LiquidationPairFactory {
       _liquidityFraction,
       _virtualReserveIn,
       _virtualReserveOut,
-      _mink
+      _mink,
+      _maxPriceImpact
     );
 
     allPairs.push(_liquidationPair);
@@ -93,7 +96,8 @@ contract LiquidationPairFactory {
       _liquidityFraction,
       _virtualReserveIn,
       _virtualReserveOut,
-      _mink
+      _mink,
+      _maxPriceImpact
     );
 
     return _liquidationPair;

--- a/src/libraries/FixedMathLib.sol
+++ b/src/libraries/FixedMathLib.sol
@@ -10,7 +10,7 @@ type UFixed32x4 is uint32;
  * @notice A minimal library to do fixed point operations with 4 decimals of precision.
  */
 library FixedMathLib {
-  uint256 constant multiplier = 1e4;
+  uint256 public constant multiplier = 1e4;
 
   /**
    * @notice Multiply a uint256 by a UFixed32x4.

--- a/test/LiquidationPair.t.sol
+++ b/test/LiquidationPair.t.sol
@@ -1302,47 +1302,6 @@ contract LiquidationPairUnitTest is LiquidationPairTestSetup {
     );
   }
 
-  function testSwapExactAmountOut_Chuck() public {
-    uint256 minK = 800000000000000000000000000000000000;
-    // Minimize the swap multiplier and maximize liquidity fraction
-    UFixed32x4 swapMultiplier = UFixed32x4.wrap(3000);
-    UFixed32x4 liquidityFraction = UFixed32x4.wrap(200);
-    uint128 virtualReserveIn = 1000000000000000000;
-    uint128 virtualReserveOut = 1000000000000000000;
-    uint256 amountOfYield = 105108501945266277;
-
-    LiquidationPair liquidationPair = new LiquidationPair(
-      ILiquidationSource(source),
-      tokenIn,
-      tokenOut,
-      swapMultiplier,
-      liquidityFraction,
-      virtualReserveIn,
-      virtualReserveOut,
-      minK
-    );
-
-    mockLiquidatableBalanceOf(source, tokenOut, amountOfYield);
-
-    uint256 amountOut = liquidationPair.maxAmountOut();
-    console.log("Amount of yield  %s", amountOfYield);
-    console.log("Max amount out   %s", amountOut);
-    uint256 amountIn = liquidationPair.computeExactAmountIn(amountOut);
-    console.log("amountIn         %s", amountIn);
-    uint256 amountOutMin = liquidationPair.computeExactAmountOut(amountIn);
-    console.log("amountOutMin     %s", amountOutMin);
-
-    vm.prank(alice);
-
-    mockLiquidateGivenAmountIn(liquidationPair, alice, amountIn, true);
-
-    uint256 swappedAmountOut = liquidationPair.swapExactAmountIn(alice, amountIn, amountOutMin);
-    console.log("swappedAmountOut %s", swappedAmountOut);
-
-    assertEq(liquidationPair.virtualReserveIn(), 0);
-    assertEq(liquidationPair.virtualReserveOut(), 0);
-  }
-
   function testFailSwapExactAmountOut_MoreThanYieldOut() public {
     uint256 amountOut = 100e18;
     uint256 amountOfYield = 10e18;

--- a/test/LiquidationPairFactory.t.sol
+++ b/test/LiquidationPairFactory.t.sol
@@ -30,7 +30,8 @@ contract LiquidationPairFactoryTest is BaseSetup {
     UFixed32x4 liquidityFraction,
     uint128 virtualReserveIn,
     uint128 virtualReserveOut,
-    uint256 minK
+    uint256 minK,
+    UFixed32x4 maxPriceImpact
   );
 
   /* ============ Set up ============ */
@@ -60,7 +61,8 @@ contract LiquidationPairFactoryTest is BaseSetup {
       UFixed32x4.wrap(.02e4),
       100,
       100,
-      200
+      200,
+      UFixed32x4.wrap(9999)
     );
 
     LiquidationPair lp = factory.createPair(
@@ -71,7 +73,8 @@ contract LiquidationPairFactoryTest is BaseSetup {
       UFixed32x4.wrap(.02e4),
       100,
       100,
-      200
+      200,
+      UFixed32x4.wrap(9999)
     );
 
     mockTarget(source, target);
@@ -97,7 +100,8 @@ contract LiquidationPairFactoryTest is BaseSetup {
       UFixed32x4.wrap(0),
       100,
       100,
-      200
+      200,
+      UFixed32x4.wrap(9999)
     );
   }
 
@@ -113,7 +117,8 @@ contract LiquidationPairFactoryTest is BaseSetup {
       UFixed32x4.wrap(.02e4),
       100,
       100,
-      200
+      200,
+      UFixed32x4.wrap(9999)
     );
     assertEq(factory.totalPairs(), 1);
   }

--- a/test/LiquidationRouter.t.sol
+++ b/test/LiquidationRouter.t.sol
@@ -33,6 +33,7 @@ contract LiquidationRouterTest is BaseSetup {
   uint128 public defaultVirtualReserveIn;
   uint128 public defaultVirtualReserveOut;
   uint256 public defaultMinK;
+  UFixed32x4 public defaultMaxPriceImpact;
 
   LiquidationPairFactory public factory;
   address public source;
@@ -53,6 +54,7 @@ contract LiquidationRouterTest is BaseSetup {
     defaultVirtualReserveIn = 100e18;
     defaultVirtualReserveOut = 100e18;
     defaultMinK = 1e8;
+    defaultMaxPriceImpact = UFixed32x4.wrap(9999);
 
     tokenIn = utils.generateAddress("tokenIn");
     tokenOut = utils.generateAddress("tokenOut");
@@ -83,7 +85,8 @@ contract LiquidationRouterTest is BaseSetup {
       defaultLiquidityFraction,
       defaultVirtualReserveIn,
       defaultVirtualReserveOut,
-      defaultMinK
+      defaultMinK,
+      defaultMaxPriceImpact
     );
 
     mockSwapIn(
@@ -113,7 +116,8 @@ contract LiquidationRouterTest is BaseSetup {
       defaultLiquidityFraction,
       defaultVirtualReserveIn,
       defaultVirtualReserveOut,
-      defaultMinK
+      defaultMinK,
+      defaultMaxPriceImpact
     );
 
     mockSwapOut(
@@ -178,7 +182,7 @@ contract LiquidationRouterTest is BaseSetup {
     );
   }
 
-  // NOTE: Function selector of safeTransferFrom wasn't working
+  // Note: Function selector of safeTransferFrom wasn't working
   function mockTransferFrom(address _token, address _from, address _to, uint256 _amount) internal {
     vm.mockCall(
       _token,

--- a/test/mocks/MockLiquidatorLib.sol
+++ b/test/mocks/MockLiquidatorLib.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.17;
 
-import "../../src/libraries/LiquidatorLib.sol";
+import "src/libraries/LiquidatorLib.sol";
+import { UFixed32x4, FixedMathLib } from "src/libraries/FixedMathLib.sol";
+
+import { Math } from "openzeppelin/utils/math/Math.sol";
 
 // Note: Need to store the results from the library in a variable to be picked up by forge coverage
 // See: https://github.com/foundry-rs/foundry/pull/3128#issuecomment-1241245086
@@ -11,13 +14,15 @@ contract MockLiquidatorLib {
     uint128 _reserveA,
     uint128 _reserveB,
     uint256 _amountInB,
-    uint256 _amountOutB
+    uint256 _amountOutB,
+    UFixed32x4 _maxPriceImpact
   ) public pure returns (uint256) {
     uint256 amountIn = LiquidatorLib.computeExactAmountIn(
       _reserveA,
       _reserveB,
       _amountInB,
-      _amountOutB
+      _amountOutB,
+      _maxPriceImpact
     );
     return amountIn;
   }
@@ -26,13 +31,15 @@ contract MockLiquidatorLib {
     uint128 _reserveA,
     uint128 _reserveB,
     uint256 _amountInB,
-    uint256 _amountInA
+    uint256 _amountInA,
+    UFixed32x4 _maxPriceImpact
   ) public pure returns (uint256) {
     uint256 amountOut = LiquidatorLib.computeExactAmountOut(
       _reserveA,
       _reserveB,
       _amountInB,
-      _amountInA
+      _amountInA,
+      _maxPriceImpact
     );
     return amountOut;
   }
@@ -40,14 +47,12 @@ contract MockLiquidatorLib {
   function virtualBuyback(
     uint128 _reserveA,
     uint128 _reserveB,
-    uint256 _amountInB
-  ) public pure returns (uint128, uint128) {
-    (uint128 reserveA, uint128 reserveB) = LiquidatorLib._virtualBuyback(
-      _reserveA,
-      _reserveB,
-      _amountInB
-    );
-    return (reserveA, reserveB);
+    uint256 _amountInB,
+    UFixed32x4 _maxPriceImpact
+  ) public pure returns (uint128, uint128, uint256, uint256) {
+    (uint128 reserveA, uint128 reserveB, uint256 amountInB, uint256 amountOutA) = LiquidatorLib
+      ._virtualBuyback(_reserveA, _reserveB, _amountInB, _maxPriceImpact);
+    return (reserveA, reserveB, amountInB, amountOutA);
   }
 
   function virtualSwap(
@@ -95,7 +100,8 @@ contract MockLiquidatorLib {
     uint256 _amountInA,
     UFixed32x4 _swapMultiplier,
     UFixed32x4 _liquidityFraction,
-    uint128 _minK
+    uint128 _minK,
+    UFixed32x4 _maxPriceImpact
   ) public pure returns (uint256, uint256, uint256) {
     (uint256 reserveA, uint256 reserveB, uint256 amountOut) = LiquidatorLib.swapExactAmountIn(
       _reserveA,
@@ -104,7 +110,8 @@ contract MockLiquidatorLib {
       _amountInA,
       _swapMultiplier,
       _liquidityFraction,
-      _minK
+      _minK,
+      _maxPriceImpact
     );
     return (reserveA, reserveB, amountOut);
   }
@@ -116,7 +123,8 @@ contract MockLiquidatorLib {
     uint256 _amountOutB,
     UFixed32x4 _swapMultiplier,
     UFixed32x4 _liquidityFraction,
-    uint128 _minK
+    uint128 _minK,
+    UFixed32x4 _maxPriceImpact
   ) public pure returns (uint256, uint256, uint256) {
     (uint256 reserveA, uint256 reserveB, uint256 amountIn) = LiquidatorLib.swapExactAmountOut(
       _reserveA,
@@ -125,26 +133,121 @@ contract MockLiquidatorLib {
       _amountOutB,
       _swapMultiplier,
       _liquidityFraction,
-      _minK
+      _minK,
+      _maxPriceImpact
     );
     return (reserveA, reserveB, amountIn);
   }
 
   function getAmountOut(
-    uint256 amountIn,
-    uint128 virtualReserveIn,
-    uint128 virtualReserveOut
+    uint256 amountInA,
+    uint128 virtualReserveA,
+    uint128 virtualReserveB
   ) public pure returns (uint256) {
-    uint256 amountOut = LiquidatorLib.getAmountOut(amountIn, virtualReserveIn, virtualReserveOut);
+    uint256 amountOut = LiquidatorLib.getAmountOut(amountInA, virtualReserveA, virtualReserveB);
     return amountOut;
   }
 
   function getAmountIn(
-    uint256 amountOut,
-    uint128 virtualReserveIn,
-    uint128 virtualReserveOut
+    uint256 amountOutB,
+    uint128 virtualReserveA,
+    uint128 virtualReserveB
   ) public pure returns (uint256) {
-    uint256 amountIn = LiquidatorLib.getAmountIn(amountOut, virtualReserveIn, virtualReserveOut);
+    uint256 amountIn = LiquidatorLib.getAmountIn(amountOutB, virtualReserveA, virtualReserveB);
     return amountIn;
+  }
+
+  function getVirtualBuybackAmounts(
+    uint256 amountInA,
+    uint128 virtualReserveA,
+    uint128 virtualReserveB,
+    UFixed32x4 maxPriceImpactA
+  ) public pure returns (uint256, uint256) {
+    (uint256 amountOut0, uint256 amountIn1) = LiquidatorLib.getVirtualBuybackAmounts(
+      amountInA,
+      virtualReserveA,
+      virtualReserveB,
+      maxPriceImpactA
+    );
+    return (amountOut0, amountIn1);
+  }
+
+  function calculateRestrictedAmounts(
+    uint128 virtualReserveA,
+    uint128 virtualReserveB,
+    UFixed32x4 maxPriceImpactA
+  ) public pure returns (uint256, uint256) {
+    (uint256 amountIn1, uint256 amountOut0) = LiquidatorLib.calculateRestrictedAmounts(
+      virtualReserveA,
+      virtualReserveB,
+      maxPriceImpactA
+    );
+    return (amountIn1, amountOut0);
+  }
+
+  function calculateRestrictedAmountsInverted(
+    uint128 virtualReserveA,
+    uint128 virtualReserveB,
+    UFixed32x4 maxPriceImpactA
+  ) public pure returns (uint256, uint256) {
+    (uint256 amountIn1, uint256 amountOut0) = LiquidatorLib.calculateRestrictedAmountsInverted(
+      virtualReserveA,
+      virtualReserveB,
+      maxPriceImpactA
+    );
+    return (amountIn1, amountOut0);
+  }
+
+  function calculateVirtualSwapPriceImpact(
+    uint256 amountIn1,
+    uint128 reserve1,
+    uint128 reserve0
+  ) public pure returns (UFixed32x4) {
+    (UFixed32x4 priceImpact, ) = LiquidatorLib.calculateVirtualSwapPriceImpact(
+      amountIn1,
+      reserve1,
+      reserve0
+    );
+    return priceImpact;
+  }
+
+  function calculateMaxAmountOut(
+    uint256 amountIn1,
+    uint128 reserve1,
+    uint128 reserve0,
+    UFixed32x4 maxPriceImpact1
+  ) public pure returns (uint256) {
+    (UFixed32x4 priceImpact1, ) = LiquidatorLib.calculateVirtualSwapPriceImpact(
+      amountIn1,
+      reserve1,
+      reserve0
+    );
+    if (UFixed32x4.unwrap(priceImpact1) > UFixed32x4.unwrap(maxPriceImpact1)) {
+      (uint256 maxAmountIn1, ) = LiquidatorLib.calculateRestrictedAmounts(
+        reserve1,
+        reserve0,
+        maxPriceImpact1
+      );
+      return maxAmountIn1;
+    }
+
+    return amountIn1;
+  }
+
+  function calculateMaxAmountIn(
+    uint256 _amountIn1,
+    uint128 reserve1,
+    uint128 reserve0,
+    UFixed32x4 maxPriceImpact1
+  ) public pure returns (uint256) {
+    (, uint256 amountIn1) = LiquidatorLib.getVirtualBuybackAmounts(
+      _amountIn1,
+      reserve1,
+      reserve0,
+      maxPriceImpact1
+    );
+
+    return
+      LiquidatorLib.computeExactAmountIn(reserve0, reserve1, amountIn1, amountIn1, maxPriceImpact1);
   }
 }


### PR DESCRIPTION
#### Problem

If amount of yield available is too large relative to the current values stored in virtual reserves, after the virtual buyback of yield to alter prices the virtual reserves get destroyed. This results in the liquidator having a very low price for the yield that the user is buying and will take a long time for the reserve to recover, meaning yield will be sold for well below market rate for a long time until the user swaps & swap multipliers push the price back up.

#### Solution(s)

Configure a maximum [Price Impact](https://support.uniswap.org/hc/en-us/articles/8643794102669-Price-Impact-vs-Price-Slippage) on the value the token being liquidated for the virtual buyback. Two ways to do this:

1. Limit the amount of yield that is used in the virtual buyback and therefore restricting the max amount that the swapper can receive.
2. If the impact of a virtual buyback of X exceeds the maximum price impact then inflate the virtual reserves such that X causes the configured maximum price impact.

I went with solution 1. While 1 limits access to yield, users can still swap up to the maximum amount configured and can make another swap after. 2 has the side effect of reducing the effectiveness of the users swap & swap multiplier on pushing the price back up which would result in even more problems.

#### Notes

- `calculateRestrictedAmounts`. `r0' = sqrt(r0 * r1 * p1')` is prone to overflows. `r0*r1 <= uint224`, `p1 <= uint128`. 

  - `p1` (“price of token 1”, token 1 is the token being liquidated) must be scaled up to retain accuracy otherwise we run into scenarios where we have a “price” of 0. 
    - Solution is to invert the equations and use `p0` (“price of token 0”) in `calculateRestrictedAmountsInverted`. By using the price in the other direction we have smaller numbers to work with however we need to do additional math to calculate the needed price impact on token 0 that results in the desirect price impact on token 1.

- I don’t really like the `calculateRestrictedAmounts` and `calculateRestrictedAmountsInverted` functions. This is where the bulk of my time has been spent. They can definitely be optimized but I haven’t found a nice way of rearranging the formulae while maintaining precision and not discovering some new overflow issue that needs to be mitigated. 

- Price impact of token out (the token being liquidated) is restricted to <100% and >=0.01%.

  - Ie. Can’t decrease more than it’s entire value. Must have a max impact that is at least 0.01%.

- `testComputeExactAmountOut_Fuzz` these fuzz tests aren’t great. They’re testing wide ranges of inputs to the functions, but a lot of tailoring needs to be done to ensure these inputs don’t hit require statements. Tailoring these inputs so much is hard since we need to work backwards from our checks and build up these random inputs accordingly. This fuzz test in particular is hard to write and seems to be hitting the cap on retries (or it’s just wrong.).